### PR TITLE
Fix specification of raster direction to be more consistent

### DIFF
--- a/noether_msgs/msg/PlaneSlicerRasterGeneratorConfig.msg
+++ b/noether_msgs/msg/PlaneSlicerRasterGeneratorConfig.msg
@@ -12,7 +12,6 @@ bool generate_extra_rasters  # Whether an extra raster stroke should be added to
 bool raster_wrt_global_axes
 
 # Normal of the cutting planes.  Points from the first raster to the second raster, not the
-# direction from the first point in one raster to the second point of the same raster.  X is the
-# longest direction of the bounding box, Z is the shortest, Y is middle, following right hand rule.
-# If left as 0 (magnitude < 0.000001), defaults to [0,1,0], the mid direction of the bounding box.
+# direction from the first point in one raster to the second point of the same raster.  Specified
+# in the frame of the input mesh.  Overrides raster_wrt_global_axes
 geometry_msgs/Vector3 raster_direction

--- a/tool_path_planner/include/tool_path_planner/plane_slicer_raster_generator.h
+++ b/tool_path_planner/include/tool_path_planner/plane_slicer_raster_generator.h
@@ -59,7 +59,7 @@ public:
     double search_radius{ DEFAULT_SEARCH_RADIUS };
     double min_hole_size{ DEFAULT_MIN_HOLE_SIZE };
     bool raster_wrt_global_axes{ DEFAULT_RASTER_WRT_GLOBAL_AXES };
-    Eigen::Vector3d raster_direction{ Eigen::Vector3d::UnitY() };
+    Eigen::Vector3d raster_direction{ Eigen::Vector3d::Zero() };
     bool generate_extra_rasters{ DEFAULT_GENERATE_EXTRA_RASTERS };
     RasterStyle raster_style{ DEFAULT_RASTER_STYLE };
     Json::Value toJson() const

--- a/tool_path_planner/src/plane_slicer_raster_generator.cpp
+++ b/tool_path_planner/src/plane_slicer_raster_generator.cpp
@@ -597,6 +597,7 @@ boost::optional<ToolPaths> PlaneSlicerRasterGenerator::generate()
   Vector3d raster_dir;
   if (config_.raster_direction.isApprox(Eigen::Vector3d::Zero()))
   {
+    ROS_ERROR("APPROX ZERO");
     // If no direction was specified, use the middle dimension of the bounding box
     raster_dir = Eigen::Vector3d::UnitY();
     raster_dir = (rotation_offset * raster_dir).normalized();
@@ -604,7 +605,7 @@ boost::optional<ToolPaths> PlaneSlicerRasterGenerator::generate()
   else
   {
     // If a direction was specified, transform it into the frame of the bounding box
-    raster_dir = (t * rotation_offset * config_.raster_direction).normalized();
+    raster_dir = (rotation_offset * t * config_.raster_direction).normalized();
   }
 
   // Calculate all 8 corners projected onto the raster direction vector

--- a/tool_path_planner/src/plane_slicer_raster_generator.cpp
+++ b/tool_path_planner/src/plane_slicer_raster_generator.cpp
@@ -607,10 +607,11 @@ boost::optional<ToolPaths> PlaneSlicerRasterGenerator::generate()
   else
   {
     // If a direction was specified, transform it into the frame of the bounding box
-    raster_dir =
-        (rotation_offset *                                  // Rotation about short axis of bounding box
-         AngleAxisd(computeRotation(x_dir, y_dir, z_dir)) * // Rotation part of 't' (recalculated because Eigen makes it hard to access)
-         config_.raster_direction).normalized();            // Raster direction specified by user
+    raster_dir = (rotation_offset *                                   // Rotation about short axis of bounding box
+                  AngleAxisd(computeRotation(x_dir, y_dir, z_dir)) *  // Rotation part of 't' (recalculated because
+                                                                      // Eigen makes it hard to access)
+                  config_.raster_direction)                           // Raster direction specified by user
+                     .normalized();
   }
 
   // Calculate all 8 corners projected onto the raster direction vector

--- a/tool_path_planner/src/plane_slicer_raster_generator.cpp
+++ b/tool_path_planner/src/plane_slicer_raster_generator.cpp
@@ -507,6 +507,8 @@ boost::optional<ToolPaths> PlaneSlicerRasterGenerator::generate()
   using namespace Eigen;
   using IDVec = std::vector<vtkIdType>;
 
+  console_bridge::setLogLevel(console_bridge::LogLevel::CONSOLE_BRIDGE_LOG_ERROR);
+
   if (!mesh_data_)
   {
     CONSOLE_BRIDGE_logDebug("%s No mesh data has been provided", getName().c_str());
@@ -605,7 +607,10 @@ boost::optional<ToolPaths> PlaneSlicerRasterGenerator::generate()
   else
   {
     // If a direction was specified, transform it into the frame of the bounding box
-    raster_dir = (rotation_offset * t * config_.raster_direction).normalized();
+    raster_dir =
+        (rotation_offset *                                  // Rotation about short axis of bounding box
+         AngleAxisd(computeRotation(x_dir, y_dir, z_dir)) * // Rotation part of 't' (recalculated because Eigen makes it hard to access)
+         config_.raster_direction).normalized();            // Raster direction specified by user
   }
 
   // Calculate all 8 corners projected onto the raster direction vector

--- a/tool_path_planner/src/plane_slicer_raster_generator.cpp
+++ b/tool_path_planner/src/plane_slicer_raster_generator.cpp
@@ -594,7 +594,18 @@ boost::optional<ToolPaths> PlaneSlicerRasterGenerator::generate()
   Isometry3d rotation_offset = Isometry3d::Identity() * AngleAxisd(config_.raster_rot_offset, Vector3d::UnitZ());
 
   // Calculate direction of raster strokes, rotated by the above-specified amount
-  Vector3d raster_dir = (rotation_offset * config_.raster_direction).normalized();
+  Vector3d raster_dir;
+  if (config_.raster_direction.isApprox(Eigen::Vector3d::Zero()))
+  {
+    // If no direction was specified, use the middle dimension of the bounding box
+    config_.raster_direction = Eigen::Vector3d::UnitY();
+    raster_dir = (rotation_offset * config_.raster_direction).normalized();
+  }
+  else
+  {
+    // If a direction was specified, transform it into the frame of the bounding box
+    raster_dir = (t * rotation_offset * config_.raster_direction).normalized();
+  }
 
   // Calculate all 8 corners projected onto the raster direction vector
   Eigen::VectorXd dist(8);

--- a/tool_path_planner/src/plane_slicer_raster_generator.cpp
+++ b/tool_path_planner/src/plane_slicer_raster_generator.cpp
@@ -598,8 +598,8 @@ boost::optional<ToolPaths> PlaneSlicerRasterGenerator::generate()
   if (config_.raster_direction.isApprox(Eigen::Vector3d::Zero()))
   {
     // If no direction was specified, use the middle dimension of the bounding box
-    config_.raster_direction = Eigen::Vector3d::UnitY();
-    raster_dir = (rotation_offset * config_.raster_direction).normalized();
+    raster_dir = Eigen::Vector3d::UnitY();
+    raster_dir = (rotation_offset * raster_dir).normalized();
   }
   else
   {

--- a/tool_path_planner/src/utilities.cpp
+++ b/tool_path_planner/src/utilities.cpp
@@ -493,7 +493,7 @@ void testAndMark(tlist_it& item1, tlist_it& item2, double point_spacing)
   //  Eigen::Vector3d v = wp1.translation() - wp2.translation();
   //  if (v.norm() < 0.75 * point_spacing)
   double dist = fabs(std::get<0>(*item1) - std::get<0>(*item2));
-  if(dist < 0.75 * point_spacing)
+  if (dist < 0.75 * point_spacing)
   {
     if (mark1 == 1 && mark2 == 0)
     {
@@ -564,20 +564,22 @@ ToolPath sortAndSegment(std::list<std::tuple<double, Eigen::Isometry3d, int> >& 
     // spacing computed using dot-distance is close to the point spacing AND
     // spacing computed using cartesian distance is close to point spacing
     // then add add to segment
-    if (dot_spacing  > .7 * point_spacing && dot_spacing  <= 1.3 * point_spacing &&
-	cart_spacing > .7 * point_spacing && cart_spacing <= 1.3 * point_spacing ||
-	(mark == 1 && dot_spacing >0.0 && cart_spacing< 1.3 * point_spacing))
+    if (dot_spacing > .7 * point_spacing && dot_spacing <= 1.3 * point_spacing && cart_spacing > .7 * point_spacing &&
+            cart_spacing <= 1.3 * point_spacing ||
+        (mark == 1 && dot_spacing > 0.0 && cart_spacing < 1.3 * point_spacing))
     {
       seg.push_back(waypoint);
       last_wp = waypoint;
       last_dot = std::get<0>(waypoint_tuple);
     }
-    else if (dot_spacing > 1.3 * point_spacing && cart_spacing > 1.3 * point_spacing) // only add extra if dot spacing is large
-    {  // start a new segment
-      if(seg.size()>3)
-	{
-	  new_tool_path.push_back(seg); // throw away very short segments
-	}
+    // only add extra if dot spacing is large
+    else if (dot_spacing > 1.3 * point_spacing && cart_spacing > 1.3 * point_spacing)
+    {
+      // start a new segment
+      if (seg.size() > 3)
+      {
+        new_tool_path.push_back(seg);  // throw away very short segments
+      }
       seg.clear();
       seg.push_back(waypoint);
       last_wp = waypoint;
@@ -585,18 +587,18 @@ ToolPath sortAndSegment(std::list<std::tuple<double, Eigen::Isometry3d, int> >& 
     }
     else
     {  // skip unless last in list, significantly spaced from last waypoint, but not too far
-      if (q == waypoint_list.size() - 1 && dot_spacing > .3 * point_spacing && cart_spacing < 1.3*point_spacing)
+      if (q == waypoint_list.size() - 1 && dot_spacing > .3 * point_spacing && cart_spacing < 1.3 * point_spacing)
       {
-	//        seg.push_back(waypoint);  // keep the last on regardless of distance to proces up to the defined edges
+        // seg.push_back(waypoint);  // keep the last on regardless of distance to proces up to the defined edges
         last_dot = std::get<0>(waypoint_tuple);
       }
     }
     q++;
   }  // end for every waypoint in waypoint_list
-  if(seg.size()>3)
-    {
-      new_tool_path.push_back(seg);
-    }
+  if (seg.size() > 3)
+  {
+    new_tool_path.push_back(seg);
+  }
   return (new_tool_path);
 }
 

--- a/tool_path_planner/test/utest.cpp
+++ b/tool_path_planner/test/utest.cpp
@@ -25,11 +25,11 @@
 vtkSmartPointer<vtkPolyData> loadTempMesh()
 {
   vtkSmartPointer<vtkPolyData> polydata;
-  vtkSmartPointer<vtkPLYReader> reader = vtkSmartPointer<vtkPLYReader>::New ();
-  reader->SetFileName ("/tmp/test_mesh.ply");
-  reader->Update ();
-  polydata = reader->GetOutput ();
-  printf("Loaded /tmp/test_mesh.ply with %ld points/vertices.\n", polydata->GetNumberOfPoints ());
+  vtkSmartPointer<vtkPLYReader> reader = vtkSmartPointer<vtkPLYReader>::New();
+  reader->SetFileName("/tmp/test_mesh.ply");
+  reader->Update();
+  polydata = reader->GetOutput();
+  printf("Loaded /tmp/test_mesh.ply with %ld points/vertices.\n", polydata->GetNumberOfPoints());
   return polydata;
 }
 
@@ -269,7 +269,7 @@ void runTestCaseRansac(tool_path_planner::PathGenerator& planner, vtkSmartPointe
 void runExtraRasterTest(tool_path_planner::PathGenerator& planner,
                         tool_path_planner::PathGenerator& planner_with_extras,
                         vtkSmartPointer<vtkPolyData> mesh,
-      double scale = 1.0)
+                        double scale = 1.0)
 {
   // Set input mesh
   planner.setInput(mesh);
@@ -409,7 +409,6 @@ void runExtraRasterTest(tool_path_planner::PathGenerator& planner,
 #endif
 }
 
-/*
 TEST(IntersectTest, SurfaceWalkRasterRotationTest)
 {
   vtkSmartPointer<vtkPolyData> mesh = createTestMesh1();
@@ -480,7 +479,7 @@ TEST(IntersectTest, PlaneSlicerRasterSpecificDirectionTest)
   tool.min_hole_size = 0.1;
   tool.raster_rot_offset = 0.0;
   tool.raster_wrt_global_axes = false;
-  tool.raster_direction = Eigen::Vector3d::UnitY();
+  tool.raster_direction = Eigen::Vector3d::UnitX();
   //    tool.debug = false;
   planner.setConfiguration(tool);
   runRasterRotationTest(planner, mesh);
@@ -628,7 +627,7 @@ TEST(IntersectTest, SurfaceWalkExtraRasterTest)
 
   runExtraRasterTest(planner, planner_with_extra, mesh);
 }
-*/
+
 TEST(PlaneSlicerTest, PlaneSlicerExtraWaypointTest)
 {
   vtkSmartPointer<vtkPolyData> mesh = createTestMesh1();

--- a/tool_path_planner/test/utest.cpp
+++ b/tool_path_planner/test/utest.cpp
@@ -5,6 +5,7 @@
  *
  */
 
+#include <console_bridge/console.h>
 #include <gtest/gtest.h>
 #include <vtk_viewer/vtk_utils.h>
 #include <vtk_viewer/vtk_viewer.h>
@@ -452,6 +453,37 @@ TEST(IntersectTest, PlaneSlicerRasterRotationTest)
     planner.setConfiguration(tool);
     runRasterRotationTest(planner, mesh);
   }
+}
+
+TEST(IntersectTest, PlaneSlicerRasterSpecificDirectionTest)
+{
+  vtkSmartPointer<vtkPolyData> mesh = createTestMesh1();
+
+  // First, run wrt_global_axes, using default axis
+  // Set input tool data
+  tool_path_planner::PlaneSlicerRasterGenerator planner;
+  tool_path_planner::PlaneSlicerRasterGenerator::Config tool;
+  tool.point_spacing = POINT_SPACING;
+  tool.raster_spacing = 0.75;
+  //    tool.tool_offset = 0.0;                // currently unused
+  tool.min_hole_size = 0.1;
+  tool.raster_rot_offset = 0.0;
+  tool.raster_wrt_global_axes = true;
+  //    tool.debug = false;
+  planner.setConfiguration(tool);
+  runRasterRotationTest(planner, mesh);
+
+  // Second, run with specified axis
+  tool.point_spacing = POINT_SPACING;
+  tool.raster_spacing = 0.75;
+  //    tool.tool_offset = 0.0;                // currently unused
+  tool.min_hole_size = 0.1;
+  tool.raster_rot_offset = 0.0;
+  tool.raster_wrt_global_axes = false;
+  tool.raster_direction = Eigen::Vector3d::UnitY();
+  //    tool.debug = false;
+  planner.setConfiguration(tool);
+  runRasterRotationTest(planner, mesh);
 }
 
 TEST(IntersectTest, HalfedgeEdgeGeneratorTestCase0)


### PR DESCRIPTION
Changes the calculation of raster direction so a user can specify the raster direction in the coordinate frame of the part.  If no raster direction is specified, the middle direction of the bounding box will still be used.