### PR TITLE
Fixed default raster direction

### DIFF
--- a/tool_path_planner/include/tool_path_planner/plane_slicer_raster_generator.h
+++ b/tool_path_planner/include/tool_path_planner/plane_slicer_raster_generator.h
@@ -64,7 +64,7 @@ public:
     bool smooth_rasters{ DEFAULT_SMOOTH_RASTERS };
     bool raster_wrt_global_axes{ DEFAULT_RASTER_WRT_GLOBAL_AXES };
     bool generate_extra_rasters{ DEFAULT_GENERATE_EXTRA_RASTERS };
-    Eigen::Vector3d raster_direction{ Eigen::Vector3d::UnitY() };
+    Eigen::Vector3d raster_direction{ Eigen::Vector3d::Zero() };
     RasterStyle raster_style{ DEFAULT_RASTER_STYLE };
     Json::Value toJson() const
     {


### PR DESCRIPTION
Fixed default raster direction to be zero vector rather than unit Y so that it defaults to longest side of bounding box